### PR TITLE
gx: update go-ws-transport

### DIFF
--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-1.2.1: QmNyxhT1VqCWtgPrX4d1UrevixVvn8QyZJMuzdvSZXUyVA
+1.2.2: QmVJGsPeK3vwtEyyTxpCs47yjBYMmYsAhEouPDF3Gb2eK3

--- a/package.json
+++ b/package.json
@@ -26,9 +26,9 @@
     },
     {
       "author": "whyrusleeping",
-      "hash": "QmSN8R5YxkLgkjeptMpAwV77m11DrHnC7LtxEvb4zFKDtt",
+      "hash": "QmdicniYXy49AFCSVTZeYmo997kT5XJRzZLokzJCrywR2U",
       "name": "go-ws-transport",
-      "version": "1.6.0"
+      "version": "1.6.1"
     },
     {
       "author": "multiformats",
@@ -42,6 +42,6 @@
   "license": "MIT",
   "name": "go-addr-util",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "1.2.1"
+  "version": "1.2.2"
 }
 


### PR DESCRIPTION
Depends on:

- https://github.com/libp2p/go-floodsub/pull/36
- https://github.com/libp2p/go-libp2p-kad-dht/pull/87


This PR with gx updates has been created using gx-workspace: https://github.com/ipfs/gx-workspace