### PR TITLE
reduce subtract filter allocations to one

### DIFF
--- a/filter.go
+++ b/filter.go
@@ -7,7 +7,7 @@ import (
 
 // SubtractFilter returns a filter func that filters all of the given addresses
 func SubtractFilter(addrs ...ma.Multiaddr) func(ma.Multiaddr) bool {
-	addrmap := make(map[string]bool)
+	addrmap := make(map[string]bool, len(addrs))
 	for _, a := range addrs {
 		addrmap[string(a.Bytes())] = true
 	}


### PR DESCRIPTION
We *should* only be calling this method once (or once every time we change the
filters) but we currently call it every, damn, dial.