### PR TITLE
Update badges for consistency across libp2p repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@ go-addr-util
 ==================
 
 [![](https://img.shields.io/badge/made%20by-Protocol%20Labs-blue.svg?style=flat-square)](http://protocol.ai)
-[![](https://img.shields.io/badge/project-libp2p-blue.svg?style=flat-square)](http://libp2p.io/)
-[![](https://img.shields.io/badge/freenode-%23libp2p-blue.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23libp2p)
+[![](https://img.shields.io/badge/project-libp2p-yellow.svg?style=flat-square)](http://libp2p.io/)
+[![](https://img.shields.io/badge/freenode-%23libp2p-yellow.svg?style=flat-square)](http://webchat.freenode.net/?channels=%23libp2p)
 [![codecov](https://codecov.io/gh/libp2p/go-addr-util/branch/master/graph/badge.svg)](https://codecov.io/gh/libp2p/go-addr-util)
 [![Travis CI](https://travis-ci.org/libp2p/go-addr-util.svg?branch=master)](https://travis-ci.org/libp2p/go-addr-util)
 


### PR DESCRIPTION
This is one of many PRs to get our README badges all consistently
referring to libp2p in places where they currently refer to IPFS.

The changes are:

- any existing "Made by Protocol Labs" badges that link to `ipn.io` have been
changed to link to `protocol.ai`
- the project badge has been changed to libp2p, and uses the `flat-yellow` style
- the IRC badge links to the `#libp2p` channel

Since this is a cookie-cutter message shared by many PRs to various repos,
not all of the changes above may apply to this specific PR.