### PR TITLE
remove unused CheckNATWarning function

### DIFF
--- a/addr.go
+++ b/addr.go
@@ -166,23 +166,3 @@ func Subtract(a, b []ma.Multiaddr) []ma.Multiaddr {
 		return true
 	})
 }
-
-// CheckNATWarning checks if our observed addresses differ. if so,
-// informs the user that certain things might not work yet
-func CheckNATWarning(observed, expected ma.Multiaddr, listen []ma.Multiaddr) {
-	if observed.Equal(expected) {
-		return
-	}
-
-	if !AddrInList(observed, listen) { // probably a nat
-		log.Warningf(natWarning, observed, listen)
-	}
-}
-
-const natWarning = `Remote peer observed our address to be: %s
-The local addresses are: %s
-Thus, connection is going through NAT, and other connections may fail.
-
-IPFS NAT traversal is still under development. Please bug us on github or irc to fix this.
-Baby steps: http://jbenet.static.s3.amazonaws.com/271dfcf/baby-steps.gif
-`

--- a/addr_test.go
+++ b/addr_test.go
@@ -223,12 +223,3 @@ func TestAddrInList(t *testing.T) {
 		t.Errorf("Expected address %s to be in list", "/ip4/0.0.0.0/tcp/1234")
 	}
 }
-
-func TestCheckNATWarning(t *testing.T) {
-	multiAddr := newMultiaddr(t, "/ip4/0.0.0.0/tcp/1234")
-	listen := []ma.Multiaddr{
-		multiAddr,
-	}
-	CheckNATWarning(multiAddr, multiAddr, listen)
-	CheckNATWarning(newMultiaddr(t, "/ip6/fe80::/tcp/1234"), multiAddr, listen)
-}


### PR DESCRIPTION
As far as I can tell, this isn't used anywhere across our stack.

Loading an image over HTTP might not be the best idea anyway - even if it's "just" a cat gif.